### PR TITLE
Remove quotes for type

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,17 +1,17 @@
 variable "aws_region" {
-  type = "string"
+  type = string
   description = "Specified AWS Region"
   default = "ap-southeast-1"
 }
 
 variable "aws_credential_profile" {
-  type = "string"
+  type = string
   description = "AWS Profile With Admin Access"
   default = ""
 }
 
 variable "phone_number_for_notification" {
-  type = "string"
+  type = string
   description = "Valid Handphone number for notification"
   default = ""
 }


### PR DESCRIPTION
`terraform init` returns error with quotes in type.

Terraform 0.11 and earlier required type constraints to be given in quotes, but that form is now deprecated
│ and will be removed in a future version of Terraform. Remove the quotes around "string".